### PR TITLE
Add files via upload

### DIFF
--- a/content/en/blog/2024-03-19-flux-kubeconeu2024.md
+++ b/content/en/blog/2024-03-19-flux-kubeconeu2024.md
@@ -1,0 +1,59 @@
+---
+author: Tamao
+date: 2024-03-19 08:00:00+00:00
+title: FluxCD project gains New Corporate Support and Ecosystem in 2024
+description: "XX"
+url: /blog/2024/03/FluxCD-project-gains-new-corporate-support-and-ecosystem-in-2024/
+tags: [announcement]
+resources:
+- src: "**.{png,jpg}"
+  title: "Image #:counter"
+---
+
+<!--
+
+Have a look at these documents
+
+- internal_docs/how-to-do-the-monthly-update.md
+  online: https://github.com/fluxcd/website/blob/main/internal_docs/how-to-do-the-monthly-update.md
+- internal_docs/how-to-write-a-blog-post.md
+  online: https://github.com/fluxcd/website/blob/main/internal_docs/how-to-write-a-blog-post.md
+
+to get more background on how to publish this blog post.
+
+-->
+
+The CNCF graduated FluxCD project is proud to announce that it will receive enhanced support from dedicated companies in 2024. These organizations are committed to the ongoing maintenance and development of Flux GitOps tools. [At KubeCon EU 2024 in Paris, the Flux project has keynote highlights, sessions, and a booth.](https://fluxcd.io/kubecon/)
+
+
+## Vendors and clouds are stepping up contributions
+
+Major vendors are ramping up their ecosystem involvement in Flux moving forward. [GitLab announced its continued support for Flux](https://about.gitlab.com/blog/2024/03/05/the-continued-support-of-fluxcd-at-gitlab/) and working with partners. In early 2023, GitLab integrated Flux with its agent for Kubernetes offering as the recommended GitOps solution. 
+
+Similarly, Flux continues to be the GitOps engine for cloud vendors such as Microsoft and AWS. Lachie Evenson at Microsoft affirms that "Flux is the engine that powers several GitOps experiences on Azure as well as in our customer’s environments” and that Microsoft is committed to upstream contributions. Both Azure and AWS use Flux to streamline Kubernetes cluster and application management, adopting GitOps principles for enhanced automation, security, and reliability in cloud-native application deployments for Azure Arc Kubernetes and EKS-Anywhere.
+
+|_"Flux is the engine that powers several GitOps experiences on Azure as well as in our customer’s environments. We will continue to invest in Flux through upstream contributions for the long-term health and support of the project, and downstream partnerships to help customers" -  Lachie Evenson, Principal PDM Manager_ – Cloud Native Ecosystem, Microsoft |
+
+## New Enterprise adopters: Silva project, Cisco, Tchibo, and more
+
+Flux’s significant benefits show in its widespread adoption by large-scale enterprises across various sectors, including telecommunications and financial services. The new Sylva project showcases [the critical role of Flux for its complex telecom cloud native environments](https://sylva-projects.gitlab.io/release-note/). Sylva streamlines the management of Kubernetes workload clusters, specifically designed to deploy Containerized Network Functions (CNF) provided by both external CNF vendors and telecom operators' in-house services. As Orange VP of Software Engineering affirms, Flux’s security, modularity, resilience, and community all contribute to how it is the GitOps framework of choice.
+
+|_"We are really happy to observe new big tech shops bringing their support to Flux. It should give to everyone the confidence to keep committing and investing. The level of quality and security, and the modularity of Flux have been prime reasons for our decision to use it two years ago to automate the deployment and lifecycle management of network functions. Our Linux Foundation Sylva-based cloud native infrastructure relies on the strength and resilience of the Flux community. Flux’s technology and community make it the GitOps framework in our Telco networks."_ - Philippe Ensarguet, VP Software Engineering, Orange|
+
+Other long-time Flux adopters who have added themselves to the public list recently include Cisco and German retailer, Tchibo.
+
+## New Support and Ecosystem: Hirings and Value-Add Extensions
+
+While several ecosystem companies are coordinating to step up as maintainers, contributors, and supporters of Flux, [ControlPlane was first to hire Stefan Prodan](https://control-plane.io/posts/controlplane-backs-the-cncf-flux-project-by-employing-maintainers/) (Flux project maintainer and architect as well as Flagger creator), Soulé Ba (maintainer), and other members of the Flux core team to continue their contributions. As ControlPlane CEO, Andrew Martin, has reinforced their commitment to maintain the project is part of their offering of access to a hardened, FIPS-compliant, enterprise-grade distribution of Flux, including support options. 
+
+|_"ControlPlane is delighted to continue supporting the Flux project for all users, and to provide organisations utilising Flux with access to a hardened, FIPS-compliant, enterprise-grade distribution of FluxCD”_ - Andrew Martin, CEO, ControlPlane|
+
+In addition, companies such as Aviator, OpsMX, OpsWorks Group, OSO and Teracloud began providing support for Flux among their offerings. At KubeCon EU 2024 in Paris, these and other companies in the ecosystem will meet at a Birds of a Feather meeting to kick off further commitments to add value to Flux’s extensibility and ecosystem reach.
+
+## Cloud Native Computing Foundation Exemplar Project
+At this juncture, the Flux project is a strong graduated project within the Cloud Native Computing Foundation with continued recognition from CNCF CTO, Chris Aniszczyk, who states how Flux exemplifies the strength and resilience of the community. Flux reached General Availability in December 2023 and blew through its second security audit with the CNCF with no CVEs. The project’s published [benchmarks](https://fluxcd.io/blog/2023/12/flux-v2.2.0/#benchmark-results) results demonstrate why cloud vendors and enterprises alike have been trusting Flux with their needs for scale.
+
+|_"I am glad to see the continued support across the open source cloud native community for Flux. I encourage other organizations to get involved as there's never a bad time to contribute to an open source project you depend on. Also, this is a great example of the strength and resilience of our community and we look forward to Flux's continued evolution and growth."_ - Chris Aniszczyk, CTO, CNCF|
+
+If you’re at KubeCon in Paris this week, visit the [Flux project booth and the many sessions,](https://fluxcd.io/kubecon/) including Stefan’s maintainer talk on the [Flux roadmap](https://github.com/fluxcd/flux2/discussions/4663) at the event.
+


### PR DESCRIPTION
Blog post for KubeCon EU 2024. Go live must be March 19, 2024 8:30 CET to align with the CNCF 9:00 CET cross-posting.